### PR TITLE
Use namespace import syntax to support newer bundlers

### DIFF
--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -1,4 +1,4 @@
-import printj from 'printj'
+import * as printj from 'printj'
 import { Table } from '../Table'
 import { LuaError } from '../LuaError'
 import { tostring, posrelat, coerceArgToNumber, coerceArgToString, hasOwnProperty, LuaType } from '../utils'


### PR DESCRIPTION
The old `import printj from 'printj'` syntax was causing an error in in a personal project where I was using Vite v4.3.9. Making this change to the import syntax and rebuilding this project solved the issue for me. This should continue to work with other build systems as well, as this syntax is widely supported, while the old syntax might break in newer build systems.