### PR TITLE
fix: setmetatable should remove the metatable if the argument is null

### DIFF
--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -256,7 +256,7 @@ function setmetatable(table: LuaType, metatable: LuaType): Table {
         throw new LuaError('cannot change a protected metatable')
     }
 
-    TABLE.metatable = coerceArgToTable(metatable, 'setmetatable', 2)
+    TABLE.metatable = metatable === null ? null : coerceArgToTable(metatable, 'setmetatable', 2) 
     return TABLE
 }
 


### PR DESCRIPTION
As per the documentation at https://www.gammon.com.au/scripts/doc.php?lua=setmetatable:

> Sets the metatable for the nominated table. **If metatable is nil, removes the metatable.** If the original metatable has a "__metatable" entry an error is raised.
> 
> Returns the table.