### PR TITLE
fix setmetatable: allow metatable argument to be optional

### DIFF
--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -256,7 +256,7 @@ function setmetatable(table: LuaType, metatable: LuaType): Table {
         throw new LuaError('cannot change a protected metatable')
     }
 
-    TABLE.metatable = metatable === null ? null : coerceArgToTable(metatable, 'setmetatable', 2) 
+    TABLE.metatable = metatable === null || metatable === undefined ? null : coerceArgToTable(metatable, 'setmetatable', 2) 
     return TABLE
 }
 


### PR DESCRIPTION
Follow up on #11.

The argument could also not be provided.