### PR TITLE
Fix: lazy evaluation for logical expressions (#27)

### DIFF
--- a/src/operators.ts
+++ b/src/operators.ts
@@ -37,8 +37,15 @@ const binaryBooleanArithmetic = (
 const bool = (value: LuaType): boolean => coerceToBoolean(value)
 
 // logical
-const and = (l: LuaType, r: LuaType): LuaType => coerceToBoolean(l) ? r : l
-const or = (l: LuaType, r: LuaType): LuaType => coerceToBoolean(l) ? l : r
+const and = (l: () => LuaType, r: () => LuaType): LuaType => {
+	const lv = l()
+	return coerceToBoolean(lv) ? r() : lv
+}
+
+const or = (l: () => LuaType, r: () => LuaType): LuaType => {
+	const lv = l()
+	return coerceToBoolean(lv) ? lv : r()
+}
 
 // unary
 const not = (value: LuaType): boolean => !bool(value)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -303,10 +303,10 @@ const generate = (node: luaparse.Node): string | MemExpr => {
             const operator = node.operator
 
             if (operator === 'and') {
-                return `__lua.and(${left},${right})`
+                return `__lua.and(() => ${left}, () => ${right})`
             }
             if (operator === 'or') {
-                return `__lua.or(${left},${right})`
+                return `__lua.or(() => ${left}, () => ${right})`
             }
             throw new Error(`Unhandled logical operator: ${node.operator}`)
         }

--- a/tests/lua-5.3/logical_operations.lua
+++ b/tests/lua-5.3/logical_operations.lua
@@ -1,0 +1,6 @@
+local x = nil
+local x_ = (x and x.k or "fallback")
+assert(x_ == "fallback")
+local y = "ok"
+local y_ = (y or error("should not raise"))
+assert(y == y_)

--- a/tests/test.js
+++ b/tests/test.js
@@ -24,6 +24,7 @@ let exitCode = 0
     })
     luaEnv.parseFile('goto.lua').exec()
     luaEnv.parseFile('bwcoercion.lua').exec()
+    luaEnv.parseFile('logical_operations.lua').exec()
 }
 
 {


### PR DESCRIPTION
This PR fixes the issue in #27 where `and`/`or` expressions triggered errors when accessing properties of `nil`. The `__lua.and` and `__lua.or` functions are updated to use lazy evaluation, ensuring proper short-circuit behavior.

#### Changes:
- Implemented lazy evaluation to prevent unnecessary evaluation of the right-hand side.

Closes #27